### PR TITLE
Support for arm64 releases.

### DIFF
--- a/Casks/kart.rb
+++ b/Casks/kart.rb
@@ -1,8 +1,11 @@
 cask "kart" do
   version "0.14.2"
-  sha256 "88550e3c022c88293220f9a25ca30b8e5a770c48986bdd30457224d6820c0e87"
+  arch arm: "arm64", intel: "x86_64"
 
-  url "https://github.com/koordinates/kart/releases/download/v#{version}/Kart-#{version}-macOS-x86_64.pkg",
+  sha256 arm:   "",
+         intel: "88550e3c022c88293220f9a25ca30b8e5a770c48986bdd30457224d6820c0e87"
+
+  url "https://github.com/koordinates/kart/releases/download/v#{version}/Kart-#{version}-macOS-#{arch}.pkg",
       verified: "github.com/koordinates/kart/"
   appcast "https://github.com/koordinates/kart/releases.atom"
   name "Kart"
@@ -11,7 +14,7 @@ cask "kart" do
 
   conflicts_with cask: "sno"
 
-  pkg "Kart-#{version}-macOS-x86_64.pkg"
+  pkg "Kart-#{version}-macOS-#{arch}.pkg"
 
   uninstall pkgutil: "com.koordinates.Sno.SnoCore"
 end

--- a/Casks/sno.rb
+++ b/Casks/sno.rb
@@ -1,8 +1,11 @@
 cask "sno" do
   version "0.14.2"
-  sha256 "88550e3c022c88293220f9a25ca30b8e5a770c48986bdd30457224d6820c0e87"
+  arch arm: "arm64", intel: "x86_64"
 
-  url "https://github.com/koordinates/kart/releases/download/v#{version}/Kart-#{version}-macOS-x86_64.pkg",
+  sha256 arm:   "",
+         intel: "88550e3c022c88293220f9a25ca30b8e5a770c48986bdd30457224d6820c0e87"
+
+  url "https://github.com/koordinates/kart/releases/download/v#{version}/Kart-#{version}-macOS-#{arch}.pkg",
       verified: "github.com/koordinates/kart/"
   appcast "https://github.com/koordinates/kart/releases.atom"
   name "Sno (now Kart)"
@@ -11,7 +14,7 @@ cask "sno" do
 
   conflicts_with cask: "kart"
 
-  pkg "Kart-#{version}-macOS-x86_64.pkg"
+  pkg "Kart-#{version}-macOS-#{arch}.pkg"
 
   uninstall pkgutil: "com.koordinates.Sno.SnoCore"
 


### PR DESCRIPTION
This is a patch for the next release of Kart which will have Apple Silicon support on macOS, but can't be merged/used as-is since it needs the releases to be available and the associated artifact hashes.

I followed the guide at https://docs.brew.sh/Cask-Cookbook#handling-different-system-configurations wrt per-platform conditionals.